### PR TITLE
Fix #89: Do not generate the geojson data for each request

### DIFF
--- a/include/functions_map.php
+++ b/include/functions_map.php
@@ -513,9 +513,13 @@ function osm_get_js($conf, $local_conf, $js_data)
 \t}";
     if (isset($local_conf['paths'])) {
         foreach ($local_conf['paths'] as $path) {
-            $ext = pathinfo($path);
-            $ext = $ext['extension'];
-            $js .= "\nomnivore.".$ext."('".$path."').addTo(".$divname.");";
+            $ext = pathinfo($path)['extension'];
+            $geojson_path = str_replace(".$ext", '.geojson', $path);
+            if (file_exists($geojson_path) and is_readable ($geojson_path)){
+                $js .= "\nomnivore.geojson('".$geojson_path."').addTo(".$divname.");";
+            } else {
+                $js .= "\nomnivore.".$ext."('".$path."').addTo(".$divname.");";
+            }
         }
     }
     $js .= "\nif (typeof L.MarkerClusterGroup === 'function')\n";


### PR DESCRIPTION
The current code use the omnivore plugin to display gpx data. It works
great but generate an ajax request to the server for each gpx files.
Once the gpx data are retrieved, the parse.gpx (or whatever) function
will generate a geojson structure to display the polygon.
If you have a lot of gpx files, this method could be a high
time-consuming process.

This patch suggests a new manual workflow to manage the gps traces:
1/ Upload/synchronize a gpx file (/path/to/galleries/dir/file.gpx)
2/ Generate a geojson file from this gpx file:

```
On a debian-based linux distribution:
  % sudo apt-get install npm
  % sudo npm install -f togeojson
  % sudo n latest
  % togeojson file.gpx > file.geojson
  % perl -p -i -n -e 's/\s//g' file.geojson # To remove space characters
```

You can also simplify the gpx file, to make it lighter, using gpxbabel:

```
  % sudo apt-get install gpsbabel
  % gpsbabel -i gpx \
      -f file.gpx \
      -x simplify,crosstrack,error=0.001k \
      -i gpx -F file_simplified.gpx
```

  It will remove points if they are no farther than 1 metre.
  For more details, see:
  https://wiki.openstreetmap.org/wiki/GPSBabel/Using_filters#Simplifying_tracks
3/ Put the geojson file in the same directory, with the same name but the
geojson extension (/path/to/galleries/dir/file.geojson).

Now the geojson file will be used instead of the gpx file, and put in
the original html document (no additional ajax requests).
