### PR TITLE
Bug fix with the smarty update to php8

### DIFF
--- a/picture.inc.php
+++ b/picture.inc.php
@@ -40,7 +40,7 @@ function osm_loc_begin_picture()
     $template->set_prefilter('picture', 'osm_insert_map');
 }
 
-function osm_insert_map($content, &$smarty)
+function osm_insert_map($content)
 {
     global $conf;
     load_language('plugin.lang', OSM_PATH);


### PR DESCRIPTION
With the smarty php8 update, we have to remove the &$smarty parameter to prefilters (that said, it was useless anyway).