### PR TITLE
Fix missing error report on installation when file system not writable.

### DIFF
--- a/maintain.class.php
+++ b/maintain.class.php
@@ -157,7 +157,10 @@ else
   include_once( PHPWG_ROOT_PATH. 'plugins/piwigo-openstreetmap/osmmap3.php');
 ?>
 EOF;
-      file_put_contents(PHPWG_ROOT_PATH.'osmmap.php', $c);
+      if (!file_put_contents(PHPWG_ROOT_PATH.'osmmap.php', $c)) {
+        error_reporting($_error_reporting);
+        throw new SmartyException("unable to write file {$PHPWG_ROOT_PATH.'osmmap.php'}");
+      }      
     }
   }
 


### PR DESCRIPTION
Report write error when installation, my piwigo root dir was not writable by piwigo, but silent error is not easy to fix. 