### PR TITLE
Fix mistaken string syntax

### DIFF
--- a/maintain.class.php
+++ b/maintain.class.php
@@ -160,7 +160,7 @@ else
 EOF;
       if (!file_put_contents(PHPWG_ROOT_PATH.'osmmap.php', $c)) {
         error_reporting($_error_reporting);
-        throw new SmartyException("unable to write file {$PHPWG_ROOT_PATH.'osmmap.php'}");
+        throw new SmartyException("unable to write file {$PHPWG_ROOT_PATH}osmmap.php");
       }      
     }
   }


### PR DESCRIPTION
The whole gallery fails to load with the plugin active*, failing on this line. I think the scope of things allowed inside the {} string interpolation is limited in PHP syntax.


*: At least on my system, PHP 7.4.33 on Debian, Piwigo 13.8.0.