### PR TITLE
fixes #240 Add option to select GPX to display

### DIFF
--- a/admin/admin_config.php
+++ b/admin/admin_config.php
@@ -127,6 +127,34 @@ $available_layout = array(
 //    '4' => 'osm-map4.tpl',
 );
 
+// $available_gpx = array();
+$forbidden = get_sql_condition_FandF(
+  array
+  (
+      'forbidden_categories' => 'ic.category_id',
+      'visible_categories' => 'ic.category_id',
+      'visible_images' => 'i.id'
+  ),
+  "\n AND"
+);
+
+$INNER_JOIN = "INNER JOIN ".CATEGORIES_TABLE." AS c ON ic.category_id = c.id";
+
+$query="SELECT i.path, i.name, i.id FROM ".IMAGES_TABLE." AS i
+INNER JOIN (".IMAGE_CATEGORY_TABLE." AS ic ".$INNER_JOIN.") ON i.id = ic.image_id
+WHERE `path` LIKE '%.gpx' ".$forbidden." ";
+
+$available_gpx = array();
+
+$result = pwg_query($query);
+while ($row = pwg_db_fetch_array($result))
+{
+  $available_gpx[ $row['id'] ] = array(
+    "id" => $row['id'],
+    "name" => $row['name'],
+  );
+}
+
 $query = 'SELECT COUNT(*) FROM '.IMAGES_TABLE.' WHERE `latitude` IS NOT NULL and `longitude` IS NOT NULL ';
 list($nb_geotagged) = pwg_db_fetch_array( pwg_query($query) );
 
@@ -173,24 +201,25 @@ if (isset($_POST['submit']) && !empty($_POST['osm_height']))
             'autocenter'        => get_boolean($_POST['osm_left_autocenter']),
             'layout'            => $_POST['osm_left_layout'],
 			),
-        'category_description' => array(
-            'enabled' => get_boolean($_POST['osm_category_description']),
-            'height'  => $_POST['osm_cat_height'],
-            'width'   => $_POST['osm_cat_width'],
-            'index'   => $_POST['osm_cat_index'],
-            ),
+  'category_description' => array(
+            'enabled'     => get_boolean($_POST['osm_category_description']),
+            'height'      => $_POST['osm_cat_height'],
+            'width'       => $_POST['osm_cat_width'],
+            'index'       => $_POST['osm_cat_index'],
+            'display_gpx' => $_POST['osm_display_gpx'],
+      ),
 	'main_menu' => array(
             'enabled' => get_boolean($_POST['osm_main_menu']),
             'height'  => $_POST['osm_menu_height'],
-            ),
-        'gpx' => array(
+      ),
+  'gpx' => array(
             'height' => $_POST['osm_gpx_height'],
             'width'  => $_POST['osm_gpx_width'],
-            ),
-        'batch' => array(
+      ),
+  'batch' => array(
             'global_height' => $_POST['osm_batch_global_height'],
             'unit_height'  => $_POST['osm_batch_unit_height'],
-            ),
+      ),
 	'map' => array(
             'baselayer'          => $_POST['osm_baselayer'],
             'custombaselayer'    => $_POST['osm_custombaselayer'],
@@ -199,8 +228,8 @@ if (isset($_POST['submit']) && !empty($_POST['osm_height']))
             'attrleaflet'        => get_boolean($_POST['osm_attrleaflet']),
             'attrimagery'        => get_boolean($_POST['osm_attrimagery']),
             'attrplugin'         => get_boolean($_POST['osm_attrplugin']),
-            'mapquestapi'        => $_POST['osm_mapquestapi'],
-            ),
+            'mapquestapi'        => isset($_POST['osm_mapquestapi']) ? $_POST['osm_mapquestapi'] : '',
+      ),
 	'pin' => array(
             'pin'            => $_POST['osm_pin'],
             'pinpath'        => $_POST['osm_pinpath'],
@@ -231,6 +260,7 @@ $template->assign(
         'AVAILABLE_PIN'        => $available_pin,
         'AVAILABLE_POPUP'      => $available_popup,
         'AVAILABLE_LAYOUT'     => $available_layout,
+        'AVAILABLE_GPX'        => $available_gpx,
         'NB_GEOTAGGED'         => $nb_geotagged,
         'OSM_PATH'             => OSM_PATH,
         'GLOBAL_MODE'          => l10n('global mode'),

--- a/admin/admin_config.tpl
+++ b/admin/admin_config.tpl
@@ -161,6 +161,15 @@ Refer to the <a href="https://github.com/xbgmsharp/piwigo-openstreetmap/wiki" ta
 				<input type="text" value="{$category_description.width}" name="osm_cat_width" size="4" required placeholder="auto"/>
 				<br/><small>{'WIDTH_DESC'|@translate}</small>
 			</li>
+      <li>
+        <label>{'DISPLAY_GPX_FILE'|@translate}</label>
+        <select name="osm_display_gpx">
+          <option value="">--</option>
+{foreach from=$AVAILABLE_GPX item=GPX_FILE}
+          <option value="{$GPX_FILE.id}" {if $category_description.display_gpx == $GPX_FILE.id} selected {/if}>{$GPX_FILE.name}</option>
+{/foreach}
+				</select><br>
+      </li>
 		</ul>
 	</fieldset>
 	<fieldset>

--- a/language/en_UK/plugin.lang.php
+++ b/language/en_UK/plugin.lang.php
@@ -150,3 +150,4 @@ $lang['USE_AS_TAG_HELP'] = 'Create tag using one or multiple value from the addr
 $lang['LANGUAGE_HELP'] = 'Fetch the result in a specific language, mostly for the country and city fields, eg: (EN:Japan, ES:Japón, FR:Japon, JP:日本)';
 $lang['AUTO_CENTER'] = 'Auto center';
 $lang['AUTO_CENTER_HELP'] = 'The map will be automatically centered and zoomed to contain all information.';
+$lang['DISPLAY_GPX_FILE'] = 'Select a GPX file to display on all category description maps';

--- a/language/fr_FR/plugin.lang.php
+++ b/language/fr_FR/plugin.lang.php
@@ -156,3 +156,4 @@ $lang['STATE'] = 'État';
 $lang['SUBURB'] = 'Faubourg';
 $lang['USE_AS_TAG'] = 'Utiliser comme étiquette';
 $lang['USE_AS_TAG_HELP'] = 'Créer une étiquette en utilisant une ou plusieurs valeurs de la partie adresse';
+$lang['DISPLAY_GPX_FILE'] = 'Sélectionnez un fichier GPX à afficher sur toutes les cartes de description des catégorie';

--- a/main.inc.php
+++ b/main.inc.php
@@ -47,6 +47,9 @@ add_event_handler('loc_begin_index_category_thumbnails', 'osm_index_cat_thumbs_d
 // Hook to add worldmap link on the index thumbnails page
 add_event_handler('loc_end_index', 'osm_end_index' );
 
+// Hook to watch if GPX file selected to be displayed on map is deleted
+add_event_handler('begin_delete_elements', 'osm_begin_delete_elements' );
+
 function osm_index_cat_thumbs_displayed()
 {
 	global $page;
@@ -124,6 +127,20 @@ function osm_blockmanager_apply($mb_arr)
 function osm_strbool($value)
 {
 	return $value ? 'true' : 'false';
+}
+
+function osm_begin_delete_elements($ids)
+{
+  global $conf;
+
+  $osm_gpx_file_to_display = $conf['osm_conf']['category_description']['display_gpx'];
+
+  if(in_array($osm_gpx_file_to_display, $ids))
+  {
+    $conf['osm_conf']['category_description']['display_gpx'] = null;
+    conf_update_param('osm_conf', serialize($conf['osm_conf']));
+  }
+
 }
 
 ?>


### PR DESCRIPTION
Add select to admin config to select one GPX to display If GPX file is selected when loading map in gallery limit query to use selected gpx file Watch if GPX file is deleted, if this happens then set osm conf to default null for gpx file

Add translation for new settings in admin