### PR TITLE
Fix issue #283 - Fix XSS vulnerability fix for parameter zoom

### DIFF
--- a/include/functions_map.php
+++ b/include/functions_map.php
@@ -308,15 +308,12 @@ function osm_get_js($conf, $local_conf, $js_data)
     $center_arr = preg_split('/,/', $center);
     $center_lat = isset($center_arr) ? $center_arr[0] : 0;
     $center_lng = isset($center_arr) ? $center_arr[1] : 0;
+    $zoom = isset($conf['osm_conf']['left_menu']['zoom']) ? $conf['osm_conf']['left_menu']['zoom'] : 2;
 
     /* If we have zoom and center coordinate, set it otherwise fallback default */
     if (isset($_GET['zoom'])) {
-        check_input_parameter('zoom', $_GET, false, '/^\d{1-2}$/',true);
+        check_input_parameter('zoom', $_GET, false, '/^\d{1,2}$/',true);
         $zoom = $_GET['zoom'];
-    } else {
-        $zoom = isset($local_conf['zoom'])
-            ? $local_conf['zoom']
-            : 2;
     }
     if (isset($_GET['center_lat'])) {
         check_input_parameter('center_lat', $_GET, false, '/^-?\d+(\.\d+)?$/',true);

--- a/include/functions_map.php
+++ b/include/functions_map.php
@@ -309,16 +309,23 @@ function osm_get_js($conf, $local_conf, $js_data)
     $center_lat = isset($center_arr) ? $center_arr[0] : 0;
     $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
-    /* If we have zoom and center coordonate, set it otherwise fallback default */
-    $zoom = isset($_GET['zoom'])
-        ? $_GET['zoom']
-        : (
-            isset($local_conf['zoom'])
-                ? $local_conf['zoom']
-                : 2
-            );
-    $center_lat = isset($_GET['center_lat']) ? $_GET['center_lat'] : $center_lat;
-    $center_lng = isset($_GET['center_lng']) ? $_GET['center_lng'] : $center_lng;
+    /* If we have zoom and center coordinate, set it otherwise fallback default */
+    if (isset($_GET['zoom'])) {
+        check_input_parameter('zoom', $_GET, false, '/^\d{1-2}$/',true);
+        $zoom = $_GET['zoom'];
+    } else {
+        $zoom = isset($local_conf['zoom'])
+            ? $local_conf['zoom']
+            : 2;
+    }
+    if (isset($_GET['center_lat'])) {
+        check_input_parameter('center_lat', $_GET, false, '/^-?\d+(\.\d+)?$/',true);
+        $center_lat = $_GET['center_lat'];
+    }
+    if (isset($_GET['center_lng'])) {
+        check_input_parameter('center_lng', $_GET, false, '/^-?\d+(\.\d+)?$/',true);
+        $center_lng = isset($_GET['center_lng']) ? $_GET['center_lng'] : $center_lng;
+    }
 
     $autocenter = isset($local_conf['autocenter'])
         ? $local_conf['autocenter']

--- a/include/functions_map.php
+++ b/include/functions_map.php
@@ -312,7 +312,7 @@ function osm_get_js($conf, $local_conf, $js_data)
 
     /* If we have zoom and center coordinate, set it otherwise fallback default */
     if (isset($_GET['zoom'])) {
-        check_input_parameter('zoom', $_GET, false, '/^\d{1,2}$/',true);
+        check_input_parameter('zoom', $_GET, false, '/^1?\d$/',true);
         $zoom = $_GET['zoom'];
     }
     if (isset($_GET['center_lat'])) {

--- a/osmmap.php
+++ b/osmmap.php
@@ -80,10 +80,19 @@ $center_arr = preg_split('/,/', $center);
 $center_lat = isset($center_arr) ? $center_arr[0] : 0;
 $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
-/* If we have zoom and center coordonate, set it otherwise fallback default */
-$zoom = isset($_GET['zoom']) ? $_GET['zoom'] : $zoom;
-$center_lat = isset($_GET['center_lat']) ? $_GET['center_lat'] : $center_lat;
-$center_lng = isset($_GET['center_lng']) ? $_GET['center_lng'] : $center_lng;
+/* If we have zoom and center coordinate, set it otherwise fallback default */
+if (isset($_GET['zoom'])) {
+    check_input_parameter('zoom', $_GET, false, '/^\d{1-2}$/',true);
+    $zoom = $_GET['zoom'];
+}
+if (isset($_GET['center_lat'])) {
+    check_input_parameter('center_lat', $_GET, false, '/^-?\d+(\.\d+)?$/',true);
+    $center_lat = $_GET['center_lat'];
+}
+if (isset($_GET['center_lng'])) {
+    check_input_parameter('center_lng', $_GET, false, '/^-?\d+(\.\d+)?$/',true);
+    $center_lng = isset($_GET['center_lng']) ? $_GET['center_lng'] : $center_lng;
+}
 
 $local_conf = array();
 $local_conf['zoom'] = $zoom;

--- a/osmmap.php
+++ b/osmmap.php
@@ -82,7 +82,7 @@ $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
 /* If we have zoom and center coordinate, set it otherwise fallback default */
 if (isset($_GET['zoom'])) {
-    check_input_parameter('zoom', $_GET, false, '/^\d{1,2}$/',true);
+    check_input_parameter('zoom', $_GET, false, '/^1?\d$/',true);
     $zoom = $_GET['zoom'];
 }
 if (isset($_GET['center_lat'])) {

--- a/osmmap.php
+++ b/osmmap.php
@@ -82,7 +82,7 @@ $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
 /* If we have zoom and center coordinate, set it otherwise fallback default */
 if (isset($_GET['zoom'])) {
-    check_input_parameter('zoom', $_GET, false, '/^\d{1-2}$/',true);
+    check_input_parameter('zoom', $_GET, false, '/^\d{1,2}$/',true);
     $zoom = $_GET['zoom'];
 }
 if (isset($_GET['center_lat'])) {

--- a/osmmap2.php
+++ b/osmmap2.php
@@ -83,7 +83,7 @@ $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
 /* If we have zoom and center coordinate, set it otherwise fallback default */
 if (isset($_GET['zoom'])) {
-    check_input_parameter('zoom', $_GET, false, '/^\d{1-2}$/',true);
+    check_input_parameter('zoom', $_GET, false, '/^\d{1,2}$/',true);
     $zoom = $_GET['zoom'];
 }
 if (isset($_GET['center_lat'])) {

--- a/osmmap2.php
+++ b/osmmap2.php
@@ -83,7 +83,7 @@ $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
 /* If we have zoom and center coordinate, set it otherwise fallback default */
 if (isset($_GET['zoom'])) {
-    check_input_parameter('zoom', $_GET, false, '/^\d{1,2}$/',true);
+    check_input_parameter('zoom', $_GET, false, '/^1?\d$/',true);
     $zoom = $_GET['zoom'];
 }
 if (isset($_GET['center_lat'])) {

--- a/osmmap2.php
+++ b/osmmap2.php
@@ -81,10 +81,19 @@ $center_arr = preg_split('/,/', $center);
 $center_lat = isset($center_arr) ? $center_arr[0] : 0;
 $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
-/* If we have zoom and center coordonate, set it otherwise fallback default */
-$zoom = isset($_GET['zoom']) ? $_GET['zoom'] : $zoom;
-$center_lat = isset($_GET['center_lat']) ? $_GET['center_lat'] : $center_lat;
-$center_lng = isset($_GET['center_lng']) ? $_GET['center_lng'] : $center_lng;
+/* If we have zoom and center coordinate, set it otherwise fallback default */
+if (isset($_GET['zoom'])) {
+    check_input_parameter('zoom', $_GET, false, '/^\d{1-2}$/',true);
+    $zoom = $_GET['zoom'];
+}
+if (isset($_GET['center_lat'])) {
+    check_input_parameter('center_lat', $_GET, false, '/^-?\d+(\.\d+)?$/',true);
+    $center_lat = $_GET['center_lat'];
+}
+if (isset($_GET['center_lng'])) {
+    check_input_parameter('center_lng', $_GET, false, '/^-?\d+(\.\d+)?$/',true);
+    $center_lng = isset($_GET['center_lng']) ? $_GET['center_lng'] : $center_lng;
+}
 
 $local_conf = array();
 $local_conf['zoom'] = $zoom;

--- a/osmmap3.php
+++ b/osmmap3.php
@@ -83,7 +83,7 @@ $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
 /* If we have zoom and center coordinate, set it otherwise fallback default */
 if (isset($_GET['zoom'])) {
-    check_input_parameter('zoom', $_GET, false, '/^\d{1-2}$/',true);
+    check_input_parameter('zoom', $_GET, false, '/^\d{1,2}$/',true);
     $zoom = $_GET['zoom'];
 }
 if (isset($_GET['center_lat'])) {

--- a/osmmap3.php
+++ b/osmmap3.php
@@ -83,7 +83,7 @@ $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
 /* If we have zoom and center coordinate, set it otherwise fallback default */
 if (isset($_GET['zoom'])) {
-    check_input_parameter('zoom', $_GET, false, '/^\d{1,2}$/',true);
+    check_input_parameter('zoom', $_GET, false, '/^1?\d$/',true);
     $zoom = $_GET['zoom'];
 }
 if (isset($_GET['center_lat'])) {

--- a/osmmap3.php
+++ b/osmmap3.php
@@ -81,10 +81,19 @@ $center_arr = preg_split('/,/', $center);
 $center_lat = isset($center_arr) ? $center_arr[0] : 0;
 $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
-/* If we have zoom and center coordonate, set it otherwise fallback default */
-$zoom = isset($_GET['zoom']) ? $_GET['zoom'] : $zoom;
-$center_lat = isset($_GET['center_lat']) ? $_GET['center_lat'] : $center_lat;
-$center_lng = isset($_GET['center_lng']) ? $_GET['center_lng'] : $center_lng;
+/* If we have zoom and center coordinate, set it otherwise fallback default */
+if (isset($_GET['zoom'])) {
+    check_input_parameter('zoom', $_GET, false, '/^\d{1-2}$/',true);
+    $zoom = $_GET['zoom'];
+}
+if (isset($_GET['center_lat'])) {
+    check_input_parameter('center_lat', $_GET, false, '/^-?\d+(\.\d+)?$/',true);
+    $center_lat = $_GET['center_lat'];
+}
+if (isset($_GET['center_lng'])) {
+    check_input_parameter('center_lng', $_GET, false, '/^-?\d+(\.\d+)?$/',true);
+    $center_lng = isset($_GET['center_lng']) ? $_GET['center_lng'] : $center_lng;
+}
 
 $local_conf = array();
 $local_conf['zoom'] = $zoom;

--- a/osmmap4.php
+++ b/osmmap4.php
@@ -83,7 +83,7 @@ $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
 /* If we have zoom and center coordinate, set it otherwise fallback default */
 if (isset($_GET['zoom'])) {
-    check_input_parameter('zoom', $_GET, false, '/^\d{1-2}$/',true);
+    check_input_parameter('zoom', $_GET, false, '/^\d{1,2}$/',true);
     $zoom = $_GET['zoom'];
 }
 if (isset($_GET['center_lat'])) {

--- a/osmmap4.php
+++ b/osmmap4.php
@@ -83,7 +83,7 @@ $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
 /* If we have zoom and center coordinate, set it otherwise fallback default */
 if (isset($_GET['zoom'])) {
-    check_input_parameter('zoom', $_GET, false, '/^\d{1,2}$/',true);
+    check_input_parameter('zoom', $_GET, false, '/^1?\d$/',true);
     $zoom = $_GET['zoom'];
 }
 if (isset($_GET['center_lat'])) {

--- a/osmmap4.php
+++ b/osmmap4.php
@@ -81,10 +81,19 @@ $center_arr = preg_split('/,/', $center);
 $center_lat = isset($center_arr) ? $center_arr[0] : 0;
 $center_lng = isset($center_arr) ? $center_arr[1] : 0;
 
-/* If we have zoom and center coordonate, set it otherwise fallback default */
-$zoom = isset($_GET['zoom']) ? $_GET['zoom'] : $zoom;
-$center_lat = isset($_GET['center_lat']) ? $_GET['center_lat'] : $center_lat;
-$center_lng = isset($_GET['center_lng']) ? $_GET['center_lng'] : $center_lng;
+/* If we have zoom and center coordinate, set it otherwise fallback default */
+if (isset($_GET['zoom'])) {
+    check_input_parameter('zoom', $_GET, false, '/^\d{1-2}$/',true);
+    $zoom = $_GET['zoom'];
+}
+if (isset($_GET['center_lat'])) {
+    check_input_parameter('center_lat', $_GET, false, '/^-?\d+(\.\d+)?$/',true);
+    $center_lat = $_GET['center_lat'];
+}
+if (isset($_GET['center_lng'])) {
+    check_input_parameter('center_lng', $_GET, false, '/^-?\d+(\.\d+)?$/',true);
+    $center_lng = isset($_GET['center_lng']) ? $_GET['center_lng'] : $center_lng;
+}
 
 $local_conf = array();
 $local_conf['zoom'] = $zoom;


### PR DESCRIPTION
As described in #283 this fixes the vulnerability by adding a `check_input_parameter`-call especially to the parameter 'zoom' for this pluging.
Further such calls are implemented for 'center_lat' and 'center_lng' parameters.
To align defined parameter handling among osmmap[2-4]?.php and include/functions_map.php a line of setting default or defined zoom-level even before the parameter is used has been added, too.